### PR TITLE
should be optional the third arguments of `regexp()`.

### DIFF
--- a/src/validators/__tests__/strings.test.ts
+++ b/src/validators/__tests__/strings.test.ts
@@ -29,13 +29,13 @@ describe("strings", () => {
     });
   });
   test("regexp", () => {
-    helper(regexp(/abcdef/, () => "", {}), "abcdef", {
+    helper(regexp(/abcdef/, () => ""), "abcdef", {
       error: false,
       message: ""
     });
   });
   test("regexp:fail", () => {
-    helper(regexp(/abcdef/, () => "error", {}), "asdef", {
+    helper(regexp(/abcdef/, () => "error"), "asdef", {
       error: true,
       message: "error"
     });

--- a/src/validators/strings.regexp.ts
+++ b/src/validators/strings.regexp.ts
@@ -4,12 +4,17 @@ export interface IRegExpOption {
   exclude?: boolean;
 }
 
+const defaultOption: IRegExpOption = {
+  exclude: false
+}
+
 export default (
   regex: RegExp,
   messager: Messager,
-  { exclude = false }: IRegExpOption
+  option?: IRegExpOption,
 ): Validator => {
-  if (exclude) {
+  const opt = { ...defaultOption, ...option }
+  if (opt.exclude) {
     return tester((target: string) => !regex.test(target), messager);
   } else {
     return tester((target: string) => regex.test(target), messager);


### PR DESCRIPTION
# About

`regexp` option should be not required, but throw TypeError if option is null or undefined.

```js
regexp(/abcdef/. () => '', {}) //=> ok

regexp(/abcdef/, () => '') //=> TypeError!!
```