### PR TITLE
Support legacy browser.

### DIFF
--- a/es6/tsconfig.json
+++ b/es6/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "esnext",
     "downlevelIteration": true,
     "esModuleInterop": true,

--- a/es6/tsconfig.json
+++ b/es6/tsconfig.json
@@ -8,6 +8,9 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "outDir": "../lib/esm",
+    "lib": [
+      "es2015"
+    ],
     "declaration": true
   },
   "include": [


### PR DESCRIPTION
# 問題

現在のバージョンをビルドすると次のソースコードが生成される．

- `lib/esm/core.js` : *before*
```js
export const tester = (test, messager) => (...args) => {
    if (!test(...args)) {
        return { error: true, message: messager(...args) };
    }
    return { error: false, message: "" };
};
```

`(...args)` や `() =>` に対応していないブラウザで上記のモジュールをimportすると，bundle後のjsがsyntax error となってしまう．

# 対応

それに従い，target の レベルをさげトランスパイルを行うように変更を加えた


- `lib/esm/core.js` : *after*
```js
export var tester = function (test, messager) { return function () {
    var args = [];
    for (var _i = 0; _i < arguments.length; _i++) {
        args[_i] = arguments[_i];
    }
    if (!test.apply(void 0, __spread(args))) {
        return { error: true, message: messager.apply(void 0, __spread(args)) };
    }
    return { error: false, message: "" };
}; };
```

これにより，モダンなシンタックスがトランスパイルされつつ，esModules の export / import は残るようになっ

# 備考

自分の差分範囲外でエラーが出ているが特に対処する必要はないですか？