### PR TITLE
v0.8 plan

### DIFF
--- a/src/__tests__/conditional.test.ts
+++ b/src/__tests__/conditional.test.ts
@@ -1,0 +1,55 @@
+import * as assert from "power-assert";
+import { combine, tester } from "../core";
+import { conditional, maxLength, minLength, required } from "../main";
+import { isString } from "../util";
+
+describe("conditional", () => {
+  test("stop early", () => {
+    const prerequiments = tester(() => false, () => "stop");
+    const dummy = tester(
+      () => {
+        assert.fail("unreachable");
+        return false;
+      },
+      () => ""
+    );
+    assert.deepStrictEqual(conditional(prerequiments, dummy)(""), {
+      error: true,
+      message: "stop"
+    });
+  });
+  test("pass requirements", () => {
+    const prerequiments = tester(() => true, () => "");
+    const dummy = tester(
+      () => {
+        return true;
+      },
+      () => "validate fail"
+    );
+    assert.deepStrictEqual(conditional(prerequiments, dummy)(""), {
+      error: false,
+      message: ""
+    });
+  });
+  test("combine and conditional", () => {
+    const precondition = combine(
+      required(() => "required"),
+      tester(str => isString(str), () => "must be string")
+    );
+    const validator = combine(
+      minLength(5, () => "min 5 length"),
+      maxLength(10, () => "max 10 length")
+    );
+    const conditionalCheckedValidator = conditional(precondition, validator);
+
+    [
+      { in: null, except: { error: true, message: "required" } },
+      { in: 123, except: { error: true, message: "must be string" } },
+      { in: "1234", except: { error: true, message: "min 5 length" } },
+      { in: "12345678910", except: { error: true, message: "max 10 length" } },
+      { in: "123456789", except: { error: false, message: "" } }
+    ].forEach(c => {
+      assert.deepStrictEqual(conditionalCheckedValidator(c.in), c.except);
+    });
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "power-assert";
-import { isBlank } from "../util";
+import { hasError, isBlank } from "../util";
 
 describe("isBlank", () => {
   test("expected true when got null", () => {
@@ -50,5 +50,51 @@ describe("isBlank", () => {
   test("expected false when got { valueOf: null }", () => {
     const actual = isBlank({ valueOf: null });
     assert.equal(actual, false);
+  });
+});
+
+describe("hasError", () => {
+  [
+    {
+      in: { error: true, message: "some" },
+      out: true
+    },
+    {
+      in: { error: false, message: "" },
+      out: false
+    },
+    {
+      in: {
+        prop1: { error: false, message: "" },
+        prop2: { error: true, message: "test" }
+      },
+      out: true
+    },
+    {
+      in: {
+        prop1: { error: false, message: "" },
+        prop2: { error: false, message: "" },
+        prop3: {
+          prop4: {
+            prop5: { error: true, message: "" }
+          }
+        }
+      },
+      out: true
+    },
+    {
+      in: {
+        prop1: { error: false, message: "" },
+        prop2: { error: false, message: "" },
+        prop3: {
+          prop4: {
+            prop5: { error: false, message: "" }
+          }
+        }
+      },
+      out: false
+    }
+  ].forEach(c => {
+    assert.equal(hasError(c.in), c.out);
   });
 });

--- a/src/async.ts
+++ b/src/async.ts
@@ -2,9 +2,9 @@ import {
   AsyncTester,
   AsyncValidator,
   defaultReducer,
-  IValidationResult,
+  ValidationResult,
   ResultReducer,
-  Validator
+  ValueValidator
 } from "./core";
 
 export const asyncTester: AsyncTester = (fn, messager) => async (...args) => {
@@ -23,7 +23,7 @@ export const asyncCombineWithReducer: (
   reducer: ResultReducer,
   i: any,
   ...t: AsyncValidator[]
-) => (...a: any[]) => Promise<IValidationResult> = (
+) => (...a: any[]) => Promise<ValidationResult> = (
   reducer,
   initialValue = { error: false, message: "" },
   ...testers
@@ -37,7 +37,7 @@ export const asyncCombineWithReducer: (
 
 export const asyncCombine: (
   ...t: AsyncValidator[]
-) => (...a: any[]) => Promise<IValidationResult> = (
+) => (...a: any[]) => Promise<ValidationResult> = (
   ...tests: AsyncValidator[]
 ) => (...args) => {
   return asyncCombineWithReducer(
@@ -47,7 +47,7 @@ export const asyncCombine: (
   )(...args);
 };
 
-export const toAsync: (t: Validator) => AsyncValidator = t => async (
+export const toAsync: (t: ValueValidator) => AsyncValidator = t => async (
   ...arg
 ) => {
   return Promise.resolve(t(...arg));

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -1,11 +1,13 @@
 import { Validator } from "./core";
+import { hasError } from "./util";
 
 export default (requirements: Validator, main: Validator): Validator => {
-  return (...args) => {
+  return <T>(...args: T[]) => {
     const precondition = requirements(...args);
-    if (precondition.error) {
+    if (hasError(precondition)) {
       return precondition;
     }
+
     return main(...args);
   };
 };

--- a/src/conditional.ts
+++ b/src/conditional.ts
@@ -1,0 +1,11 @@
+import { Validator } from "./core";
+
+export default (requirements: Validator, main: Validator): Validator => {
+  return (...args) => {
+    const precondition = requirements(...args);
+    if (precondition.error) {
+      return precondition;
+    }
+    return main(...args);
+  };
+};

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,16 +1,27 @@
 export type Test = (...v: any[]) => boolean;
 export type AsyncTest = (...v: any[]) => Promise<boolean>;
-export type Validator = (...v: any[]) => IValidationResult;
-export type AsyncValidator = (...v: any[]) => Promise<IValidationResult>;
-export type Messager = (v?: any, a?: any[]) => string;
-export type Tester = (t: Test, m: Messager) => Validator;
-export type AsyncTester = (t: AsyncTest, m: Messager) => AsyncValidator;
-export type ResultReducer = (p: any, e: IValidationResult) => any;
 
-export interface IValidationResult {
+export type SchemaValidator<T extends object> = (
+  v?: any
+) => SchemaValidationResult<T>;
+export type ValueValidator = (...v: any[]) => ValidationResult;
+export type Validator = ValueValidator | SchemaValidator<object>;
+export type AsyncValidator = (...v: any[]) => Promise<ValidationResult>;
+export type Messager = (v?: any, a?: any[]) => string;
+export type Tester = (t: Test, m: Messager) => ValueValidator;
+export type AsyncTester = (t: AsyncTest, m: Messager) => AsyncValidator;
+export type ResultReducer = (p: any, e: ValidationResult) => any;
+
+export type SchemaValidationResult<T extends object> = {
+  [P in keyof T]: T[P] extends object
+    ? SchemaValidationResult<T[P]>
+    : ValidationResult
+};
+
+export type ValidationResult = {
   error: boolean;
   message: any;
-}
+};
 
 export const tester: Tester = (test, messager) => (...args) => {
   if (!test(...args)) {
@@ -20,10 +31,10 @@ export const tester: Tester = (test, messager) => (...args) => {
 };
 
 export const combineWithReducer: (
-  t: Validator[],
+  t: ValueValidator[],
   r: ResultReducer,
   i: any
-) => (...as: any[]) => IValidationResult = (
+) => (...as: any[]) => ValidationResult = (
   validators,
   reducer,
   initialValue = { error: false, message: "" }
@@ -41,8 +52,8 @@ export const defaultReducer: ResultReducer = (m, e) => {
 };
 
 export const combine: (
-  ...t: Validator[]
-) => (...args: any[]) => IValidationResult = (...tests: Validator[]) => (
+  ...t: ValueValidator[]
+) => (...args: any[]) => ValidationResult = (...tests: ValueValidator[]) => (
   ...args: any[]
 ) => {
   return combineWithReducer(tests, defaultReducer, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,5 +18,5 @@ export { default as maxLength } from "./validators/strings.maxLength";
 export { default as minLength } from "./validators/strings.minLength";
 export { default as minDate } from "./validators/date.min";
 export { default as maxDate } from "./validators/date.max";
-export { default as shape } from "./schema";
+export { shape, safeShape } from "./schema";
 export { default as conditional } from "./conditional";

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,3 +19,4 @@ export { default as minLength } from "./validators/strings.minLength";
 export { default as minDate } from "./validators/date.min";
 export { default as maxDate } from "./validators/date.max";
 export { default as shape } from "./schema";
+export { default as conditional } from "./conditional";

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,11 +1,26 @@
-export default (obj: any) => {
-  return (o: any) => {
+import { default as conditional } from "./conditional";
+import { Messager, SchemaValidationResult, SchemaValidator } from "./core";
+import required from "./validators/required";
+
+export const shape = <T extends object>(obj: T): SchemaValidator<T> => {
+  return (o: object) => {
     return Object.keys(obj).reduce((prev, k) => {
       const validator = obj[k];
       if (validator) {
         prev[k] = validator(o[k]);
       }
       return prev;
-    }, {});
+    }, {}) as SchemaValidationResult<T>;
   };
+};
+
+const defaultBlankErrorMessager = () => "blank";
+
+export const safeShape = <T extends object>(
+  obj: T,
+  requiredMessager: Messager = defaultBlankErrorMessager
+): SchemaValidator<T> => {
+  return conditional(required(requiredMessager), shape(obj)) as SchemaValidator<
+    T
+  >;
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { SchemaValidationResult, ValidationResult } from "./core";
+
 const isNil = (arg: any): boolean => arg === null || arg === undefined;
 
 const isEmpty = (arg: any): boolean => {
@@ -25,3 +27,17 @@ export const isBlank = (s: any) => {
 };
 
 export const isString = (str: string) => typeof str === "string";
+
+export const hasError = <T>(
+  res: T extends object ? SchemaValidationResult<T> : ValidationResult
+): boolean => {
+  const result: any = res;
+  if (result.hasOwnProperty("error")) {
+    return result.error;
+  }
+  const schemaResult: SchemaValidationResult<object> = res;
+
+  return Object.keys(schemaResult).reduce((p, k) => {
+    return p || hasError(schemaResult[k]);
+  }, false);
+};

--- a/src/validators/__tests__/helper.ts
+++ b/src/validators/__tests__/helper.ts
@@ -1,7 +1,7 @@
 import * as assert from "power-assert";
-import { AsyncValidator, Validator } from "../../core";
+import { AsyncValidator, ValueValidator } from "../../core";
 
-export function helper(validator: Validator, arg: any, expect: any) {
+export function helper(validator: ValueValidator, arg: any, expect: any) {
   assert.deepStrictEqual(validator(arg), expect);
 }
 

--- a/src/validators/date.max.ts
+++ b/src/validators/date.max.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (date: Date, messager: Messager): Validator => {
+export default (date: Date, messager: Messager): ValueValidator => {
   return tester((v: Date) => {
     return date > v;
   }, messager);

--- a/src/validators/date.min.ts
+++ b/src/validators/date.min.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (date: Date, messager: Messager): Validator => {
+export default (date: Date, messager: Messager): ValueValidator => {
   return tester((v: Date) => {
     return date < v;
   }, messager);

--- a/src/validators/numbers.integer.ts
+++ b/src/validators/numbers.integer.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (messager: Messager): Validator => {
+export default (messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return Number.isInteger(v);
   }, messager);

--- a/src/validators/numbers.lessThan.ts
+++ b/src/validators/numbers.lessThan.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (max: number, messager: Messager): Validator => {
+export default (max: number, messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return v <= max;
   }, messager);

--- a/src/validators/numbers.max.ts
+++ b/src/validators/numbers.max.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (limit: number, messager: Messager): Validator => {
+export default (limit: number, messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return v > limit;
   }, messager);

--- a/src/validators/numbers.min.ts
+++ b/src/validators/numbers.min.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (limit: number, messager: Messager): Validator => {
+export default (limit: number, messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return v < limit;
   }, messager);

--- a/src/validators/numbers.moreThan.ts
+++ b/src/validators/numbers.moreThan.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (min: number, messager: Messager): Validator => {
+export default (min: number, messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return v >= min;
   }, messager);

--- a/src/validators/numbers.negative.ts
+++ b/src/validators/numbers.negative.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (messager: Messager): Validator => {
+export default (messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return v < 0;
   }, messager);

--- a/src/validators/numbers.positive.ts
+++ b/src/validators/numbers.positive.ts
@@ -1,6 +1,6 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
-export default (messager: Messager): Validator => {
+export default (messager: Messager): ValueValidator => {
   return tester((v: number) => {
     return v > 0;
   }, messager);

--- a/src/validators/required.ts
+++ b/src/validators/required.ts
@@ -1,7 +1,7 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 import { isBlank, isString } from "../util";
 
-export default (messager: Messager): Validator => {
+export default (messager: Messager): ValueValidator => {
   return tester(v => {
     if (isString(v)) {
       v = v.trim();

--- a/src/validators/strings.maxLength.ts
+++ b/src/validators/strings.maxLength.ts
@@ -1,7 +1,7 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 import { strlen } from "../util";
 
-export default (limit: number, messager: Messager): Validator => {
+export default (limit: number, messager: Messager): ValueValidator => {
   return tester((target: string) => {
     return strlen(target) < limit;
   }, messager);

--- a/src/validators/strings.minLength.ts
+++ b/src/validators/strings.minLength.ts
@@ -1,7 +1,7 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 import { strlen } from "../util";
 
-export default (limit: number, messager: Messager): Validator => {
+export default (limit: number, messager: Messager): ValueValidator => {
   return tester((target: string) => {
     return strlen(target) > limit;
   }, messager);

--- a/src/validators/strings.regexp.ts
+++ b/src/validators/strings.regexp.ts
@@ -1,4 +1,4 @@
-import { Messager, tester, Validator } from "../core";
+import { Messager, tester, ValueValidator } from "../core";
 
 export interface IRegExpOption {
   exclude?: boolean;
@@ -12,7 +12,7 @@ export default (
   regex: RegExp,
   messager: Messager,
   option?: IRegExpOption
-): Validator => {
+): ValueValidator => {
   const opt = { ...defaultOption, ...option };
   if (opt.exclude) {
     return tester((target: string) => !regex.test(target), messager);

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
   ],
   "rules": {
     "prettier": true,
+    "interface-over-type-literal": false,
     "no-implicit-dependencies": [true, "dev"]
   }
 }


### PR DESCRIPTION
changes
- remove ramda #23
- change optional params from required props of `regexp` validator #21 
- support `conditional`
- support `safeShape`
- improve typings of `shape`

breaking changes:
- change type name of `Validator` to `ValueValidator`
- change type name of `IValidationResult` to `ValidationResult` 